### PR TITLE
Fix SFML version mismatch with TGUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:texus/tgui-0.8'
         update: true
         packages:
             - autoconf
@@ -26,7 +25,6 @@ addons:
             - libopenal-dev
             - libpthread-stubs0-dev
             - libsndfile1-dev
-            - libtgui-dev
             - libtool
             - libudev-dev
             - libx11-dev
@@ -39,18 +37,25 @@ before_install:
     - CXX="g++-7"
     # SFML
     - git clone https://github.com/SFML/SFML.git
-    - cd SFML
+    - pushd SFML
     - cmake .
     - sudo make install
-    - cd ..
+    - popd
+    # TGUI - APT package uses SFML 2.3, so compile from source
+    - git clone https://github.com/texus/TGUI.git
+    - pushd TGUI
+    - git checkout 0.8
+    - cmake .
+    - sudo make install
+    - popd
     # Protobuf
     - wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${PROTOBUF_VERSION}.tar.gz
     - tar -xzvf protobuf-cpp-${PROTOBUF_VERSION}.tar.gz
-    - cd protobuf-${PROTOBUF_VERSION}
+    - pushd protobuf-${PROTOBUF_VERSION}
     - ./configure
     - sudo make install
     - sudo ldconfig
-    - cd ..
+    - popd
 jobs:
     include:
         - stage: build

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # mini-mmo-client
 [![Build Status](https://travis-ci.com/jenningsm42/mini-mmo-client.svg?branch=master)](https://travis-ci.com/jenningsm42/mini-mmo-client)
 
-The client for a very simple open world (not massively) multiplayer online game
+The client for a very simple open world (not massively) multiplayer online game. The server can be found [here](https://github.com/jenningsm42/mini-mmo-server).
 
 ## Requirements
 * Protobuf 3 compiler
 * Protobuf 3 library
-* SFML 2.5.1
-* TGUI 0.8.3
+* SFML 2.5
+* TGUI 0.8
 * CMake 3.1+
 * A C++14 compiler
 
@@ -20,7 +20,7 @@ $ cmake ..
 $ make
 ```
 
-To run:
+To run (after starting the server):
 
 ```
 $ ./build/bin/client


### PR DESCRIPTION
The TGUI APT package would install SFML 2.3 and use it instead of SFML
2.5. TGUI is now compiled from source to use SFML 2.5.