### PR TITLE
Fix draw order for other players

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,12 @@ set(SOURCE_FILES
         src/CharacterCreationScene.cpp
         src/CharacterSelectionScene.cpp
         src/Chatbox.cpp
+        src/ColorPickerWidget.cpp
         src/Game.cpp
+        src/GameObjectCollection.cpp
         src/GameScene.cpp
         src/InputHandler.cpp
         src/LoginScene.cpp
-        src/main.cpp
         src/Message.cpp
         src/OtherPlayer.cpp
         src/Player.cpp
@@ -26,7 +27,7 @@ set(SOURCE_FILES
         src/Scene.cpp
         src/SceneHandler.cpp
         src/Socket.cpp
-        src/ColorPickerWidget.cpp)
+        src/main.cpp)
 
 set(PROTO_FILES
         proto/Characters.proto

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -181,10 +181,14 @@ sf::Color Character::getLegsColor() const noexcept {
     return m_legsColor;
 }
 
-void Character::update(Game&, const GameObjectCollection&, float deltaTime) noexcept {
+void Character::update(Game&, GameObjectCollection&, float deltaTime) noexcept {
     if (m_drawable != nullptr) {
         m_drawable->update(deltaTime);
     }
+}
+
+float Character::getZIndex() const noexcept {
+    return m_position.y;
 }
 
 void Character::draw(sf::RenderTarget& target, sf::RenderStates states) const {

--- a/src/Character.hpp
+++ b/src/Character.hpp
@@ -44,7 +44,9 @@ public:
     sf::Color getShirtColor() const noexcept;
     sf::Color getLegsColor() const noexcept;
 
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
+
+    virtual float getZIndex() const noexcept override;
 
 protected:
     uint32_t m_id;

--- a/src/Chatbox.cpp
+++ b/src/Chatbox.cpp
@@ -22,7 +22,7 @@ void Chatbox::load(Game& game, uint32_t playerId, const std::string& name) {
     gui.add(m_chatbox);
 }
 
-void Chatbox::handleChatMessage(Game&, const GameObjectCollection& objects, const Message& message) noexcept {
+void Chatbox::handleChatMessage(Game&, GameObjectCollection& objects, const Message& message) noexcept {
     if (message.getType() != MessageType::ReceiveChatMessage) {
         std::cout << "Chatbox received wrong message type: " << static_cast<uint16_t>(message.getType()) << std::endl;
         return;
@@ -36,18 +36,18 @@ void Chatbox::handleChatMessage(Game&, const GameObjectCollection& objects, cons
         name = m_name;
     }
     else {
-        auto playerPool = std::dynamic_pointer_cast<PlayerPool>(objects.at("playerPool"));
+        auto playerPool = std::dynamic_pointer_cast<PlayerPool>(objects.get("playerPool"));
         name = playerPool->getPlayerName(receiveChatMessage.player_id());
     }
 
     m_chatbox->addLine("[" + name + "] " + receiveChatMessage.msg());
 }
 
-void Chatbox::update(Game& game, const GameObjectCollection& objects, float) noexcept {
+void Chatbox::update(Game& game, GameObjectCollection& objects, float) noexcept {
     auto& input = game.getInputHandler();
     auto& socket = game.getSocket();
 
-    auto player = std::dynamic_pointer_cast<Player>(objects.at("player"));
+    auto player = std::dynamic_pointer_cast<Player>(objects.get("player"));
 
     if (input.getKeyTapped(sf::Keyboard::Enter)) {
         if (m_input->isFocused()) {

--- a/src/Chatbox.hpp
+++ b/src/Chatbox.hpp
@@ -10,9 +10,9 @@ class Chatbox : public GameObject {
 public:
     void load(Game&, uint32_t playerId, const std::string& name);
 
-    void handleChatMessage(Game&, const GameObjectCollection&, const Message&) noexcept;
+    void handleChatMessage(Game&, GameObjectCollection&, const Message&) noexcept;
 
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
 
 private:
     uint32_t m_playerId;

--- a/src/GameObject.hpp
+++ b/src/GameObject.hpp
@@ -7,14 +7,19 @@
 #include <SFML/Graphics/Drawable.hpp>
 
 class Game;
+class GameObjectCollection;
 
 class GameObject;
 
-using GameObjectCollection = std::unordered_map<std::string, std::shared_ptr<GameObject>>;
-
 class GameObject : public sf::Drawable {
 public:
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept = 0;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept = 0;
+
+    // Override getZIndex to add draw order sorting
+    virtual float getZIndex() const noexcept {
+        constexpr auto minimum = std::numeric_limits<float>::min();
+        return minimum;
+    };
 
 private:
     virtual void draw(sf::RenderTarget&, sf::RenderStates) const = 0;

--- a/src/GameObjectCollection.cpp
+++ b/src/GameObjectCollection.cpp
@@ -1,0 +1,52 @@
+#include "GameObjectCollection.hpp"
+#include "GameObject.hpp"
+
+#include <algorithm>
+
+void GameObjectCollection::add(const std::string& name, std::shared_ptr<GameObject> object) {
+    m_objects.emplace(name, object);
+    m_objectsDrawOrder.push_back(object);
+}
+
+void GameObjectCollection::remove(const std::string &name) {
+    auto objectIter = m_objects.find(name);
+    if (objectIter == m_objects.end()) {
+        // No such object
+        return;
+    }
+
+    m_objectsDrawOrder.erase(
+            std::remove(m_objectsDrawOrder.begin(), m_objectsDrawOrder.end(), objectIter->second),
+            m_objectsDrawOrder.end());
+}
+
+std::shared_ptr<GameObject> GameObjectCollection::get(const std::string& name) const noexcept {
+    if (m_objects.find(name) != m_objects.end()) {
+        return m_objects.at(name);
+    }
+
+    return nullptr;
+}
+
+void GameObjectCollection::sort() noexcept {
+    // Insertion sort for draw order (most objects will not move while sorting)
+    for (size_t i = 1; i < m_objectsDrawOrder.size(); i++) {
+        for (int j = i; j > 0; j--) {
+            auto object1 = m_objectsDrawOrder[j - 1];
+            auto object2 = m_objectsDrawOrder[j];
+            if (object1->getZIndex() <= object2->getZIndex()) {
+                break;
+            }
+
+            std::swap(m_objectsDrawOrder[j], m_objectsDrawOrder[j - 1]);
+        }
+    }
+}
+
+std::vector<std::shared_ptr<GameObject>>::iterator GameObjectCollection::begin() {
+    return m_objectsDrawOrder.begin();
+}
+
+std::vector<std::shared_ptr<GameObject>>::iterator GameObjectCollection::end() {
+    return m_objectsDrawOrder.end();
+}

--- a/src/GameObjectCollection.hpp
+++ b/src/GameObjectCollection.hpp
@@ -1,0 +1,29 @@
+#ifndef GAMEOBJECTCOLLECTION_HPP
+#define GAMEOBJECTCOLLECTION_HPP
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class GameObject;
+
+class GameObjectCollection {
+public:
+    void add(const std::string& name, std::shared_ptr<GameObject>);
+    void remove(const std::string& name);
+
+    std::shared_ptr<GameObject> get(const std::string& name) const noexcept;
+
+    // Sort should be called once per frame only
+    void sort() noexcept;
+
+    std::vector<std::shared_ptr<GameObject>>::iterator begin();
+    std::vector<std::shared_ptr<GameObject>>::iterator end();
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<GameObject>> m_objects;
+    std::vector<std::shared_ptr<GameObject>> m_objectsDrawOrder;
+};
+
+#endif // GAMEOBJECTCOLLECTION_HPP

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -44,6 +44,7 @@ void GameScene::initialize(Game& game) {
             &PlayerPool::handleMessage,
             playerPool,
             std::placeholders::_1,
+            std::ref(m_objects),
             std::placeholders::_2));
     }
 
@@ -51,6 +52,6 @@ void GameScene::initialize(Game& game) {
         &Chatbox::handleChatMessage,
         chatbox,
         std::placeholders::_1,
-        m_objects,
+        std::ref(m_objects),
         std::placeholders::_2));
 }

--- a/src/OtherPlayer.cpp
+++ b/src/OtherPlayer.cpp
@@ -12,7 +12,7 @@ OtherPlayer::OtherPlayer(OtherPlayer&& other) : Character(std::move(other)) {
     m_velocity = other.m_velocity;
 }
 
-void OtherPlayer::update(Game& game, const GameObjectCollection& gameObjectCollection, float deltaTime) noexcept {
+void OtherPlayer::update(Game& game, GameObjectCollection& gameObjectCollection, float deltaTime) noexcept {
     Character::update(game, gameObjectCollection, deltaTime);
 
     m_position.x += m_velocity.x * deltaTime;

--- a/src/OtherPlayer.hpp
+++ b/src/OtherPlayer.hpp
@@ -11,7 +11,7 @@ public:
     OtherPlayer(const OtherPlayer&);
     OtherPlayer(OtherPlayer&&);
 
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
 
     void setVelocity(const sf::Vector2f& position, const sf::Vector2f& velocity) noexcept;
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -22,7 +22,7 @@ Player::Player(Player&& other) : Character(std::move(other)) {
     m_previousVelocity = std::move(other.m_previousVelocity);
 }
 
-void Player::update(Game& game, const GameObjectCollection& gameObjectCollection, float deltaTime) noexcept {
+void Player::update(Game& game, GameObjectCollection& gameObjectCollection, float deltaTime) noexcept {
     Character::update(game, gameObjectCollection, deltaTime);
 
     if (!m_controlsEnabled) {

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -11,7 +11,7 @@ public:
     Player(const Player&);
     Player(Player&&);
 
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
 
     void setControlsEnabled(bool enabled) noexcept;
 

--- a/src/PlayerPool.hpp
+++ b/src/PlayerPool.hpp
@@ -12,12 +12,13 @@
 
 class PlayerPool : public GameObject {
 public:
-    void handleMessage(Game&, const Message&) noexcept;
+    void handleMessage(Game&, GameObjectCollection&, const Message&) noexcept;
 
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
 
     void addPlayer(
         Game& game,
+        GameObjectCollection&,
         uint32_t id,
         float x,
         float y,
@@ -28,19 +29,19 @@ public:
         const sf::Color& legsColor,
         const std::string& name) noexcept;
 
-    void removePlayer(uint32_t id) noexcept;
+    void removePlayer(GameObjectCollection&, uint32_t id) noexcept;
 
     std::string getPlayerName(uint32_t id) noexcept;
 
 private:
-    std::unordered_map<uint32_t, OtherPlayer> m_players;
+    std::unordered_map<uint32_t, std::shared_ptr<OtherPlayer>> m_players;
 
     virtual void draw(sf::RenderTarget&, sf::RenderStates) const override;
 
-    void handlePlayersResponse(Game&, const PlayersResponse&);
+    void handlePlayersResponse(Game&, GameObjectCollection&, const PlayersResponse&);
 
-    void handlePlayerJoin(Game&, const PlayerJoin&);
-    void handlePlayerLeave(const PlayerLeave&);
+    void handlePlayerJoin(Game&, GameObjectCollection&, const PlayerJoin&);
+    void handlePlayerLeave(GameObjectCollection&, const PlayerLeave&);
 
     void handleOtherPlayerMove(const OtherPlayerMove&);
     void handleOtherPlayerStop(const OtherPlayerStop&);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -13,29 +13,24 @@ bool Scene::handleMessage(Game& game, const Message& message) {
 
 void Scene::update(Game& game, float deltaTime) noexcept {
     for (auto& object : m_objects) {
-        object.second->update(game, m_objects, deltaTime);
+        object->update(game, m_objects, deltaTime);
     }
 }
 
 void Scene::draw(sf::RenderWindow& window) noexcept {
-    for (auto& objects : m_objectsDrawOrder) {
-        for (auto& object : objects.second) {
-            window.draw(*object);
-        }
+    m_objects.sort();
+
+    for (auto& object : m_objects) {
+        window.draw(*object);
     }
 }
 
-std::weak_ptr<GameObject> Scene::getObject(const std::string& name) noexcept {
-    if (m_objects.find(name) != m_objects.end()) {
-        return m_objects[name];
-    }
-
-    return std::weak_ptr<GameObject>();
+void Scene::addObject(const std::string& name, std::shared_ptr<GameObject> object) {
+    m_objects.add(name, object);
 }
 
-void Scene::addObject(const std::string& name, std::shared_ptr<GameObject> object, int zIndex) {
-    m_objects.emplace(name, object);
-    m_objectsDrawOrder[zIndex].push_back(object);
+void Scene::removeObject(const std::string &name) {
+    m_objects.remove(name);
 }
 
 void Scene::addMessageHandler(MessageType type, MessageHandler handler) {

--- a/src/Scene.hpp
+++ b/src/Scene.hpp
@@ -7,6 +7,7 @@
 #include <SFML/Graphics.hpp>
 
 #include "GameObject.hpp"
+#include "GameObjectCollection.hpp"
 #include "Message.hpp"
 #include "MessageTypes.hpp"
 
@@ -15,8 +16,6 @@ class Socket;
 
 using MessageHandler = std::function<void(Game&, const Message&)>;
 using MessageHandlerMap = std::unordered_map<MessageType, MessageHandler>;
-
-using GameObjectDrawOrder = std::map<int, std::vector<std::shared_ptr<GameObject>>>;
 
 class Scene {
 public:
@@ -28,17 +27,15 @@ public:
 
     void draw(sf::RenderWindow&) noexcept;
 
-    std::weak_ptr<GameObject> getObject(const std::string& name) noexcept;
-
 protected:
     GameObjectCollection m_objects;
 
-    void addObject(const std::string& name, std::shared_ptr<GameObject>, int zIndex = 0);
+    void addObject(const std::string& name, std::shared_ptr<GameObject>);
+    void removeObject(const std::string& name);
     void addMessageHandler(MessageType, MessageHandler);
 
 private:
     MessageHandlerMap m_handlers;
-    GameObjectDrawOrder m_objectsDrawOrder;
 };
 
 #endif // SCENE_HPP


### PR DESCRIPTION
The draw order for rendering other players was not taken into account
previously, so the code was refactored to easily add objects at any
point in time to the main scene. This allows the main scene to handle
the draw order based on object height.